### PR TITLE
BUGFIX: Remove deleted LinkBuildingHelper from defaultContext

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,9 +3,6 @@ Neos:
     fusion:
       autoInclude:
         KaufmannDigital.CookieConsent: true
-  Fusion:
-    defaultContext:
-      'LinkBuilder': 'KaufmannDigital\CookieConsent\Eel\Helper\LinkBuildingHelper'
 
 KaufmannDigital:
   CookieConsent:


### PR DESCRIPTION
#4 removed the `LinkBuildingHelper`, but it did not remove it from Fusions `defaultContext`, so after flushing the cache `Neos\Eel\Utility_Original::getDefaultContextVariables()` will fail with `Class 'KaufmannDigital\CookieConsent\Eel\Helper\LinkBuildingHelper' not found`.