### PR TITLE
FEATURE: Add mixin for editing policy page in the Neos backend

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,0 +1,11 @@
+'KaufmannDigital.CookieConsent:PolicyPageMixin':
+  abstract: true
+  properties:
+    policyPage:
+      type: reference
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        inspector:
+          group: document
+          position: 'after uriPathSegment'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,13 +12,13 @@ KaufmannDigital:
     type: ''
 
     #Global configuration of PolicyPage
-    policyPageNode: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of global page you want to link
+    policyPageNode: 'needs-to-be-set' #UUID of global page you want to link
 
-    #Configuration per site for multisite installations
-    #Replace site1/site2 with your sitename (/sites/sitename/node-a2ufd/.../)
-    policyPageNodes:
-      site1: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of policy-page for /sites/site1
-      site2: '454d85b6-289b-11e9-b210-d663bd873d93' #UUID of policy-page for /sites/site2
+    # #Configuration per site for multisite installations
+    # #Replace site1/site2 with your sitename (/sites/sitename/node-a2ufd/.../)
+    # policyPageNodes:
+    #   site1: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of policy-page for /sites/site1
+    #   site2: '454d85b6-289b-11e9-b210-d663bd873d93' #UUID of policy-page for /sites/site2
 
     translations:
       package: 'KaufmannDigital.CookieConsent'

--- a/README.md
+++ b/README.md
@@ -7,25 +7,41 @@ Installation
 ------------
 
 The easiest way to install is via composer:
+
 ```bash
 composer require kaufmanndigital/cookieconsent
 ```
+
 Afterwards, you should see the Cookie Hint on your page.
 
-To configure the policy-link, you can use this snippet in your Settings.yaml`:
+To configure the policy-link, you have the following two options:
 
-```yaml
-KaufmannDigital:
-  CookieConsent:
-    #Global configuration of PolicyPage
-    policyPageNode: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of global page you want to link
+* Add the NodeType-Mixin `KaufmannDigital.CookieConsent:PolicyPageMixin` to your Home-NodeType (if you have a specific NodeType for home):
 
-    #Configuration per site for multisite installations
-    #Replace site1/site2 with your sitename (/sites/sitename/node-a2ufd/.../)
-    policyPageNodes:
-      site1: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of policy-page for /sites/site1
-      site2: '454d85b6-289b-11e9-b210-d663bd873d93' #UUID of policy-page for /sites/site2
-```
+  ```yaml
+    'Your.Package:Document.Home':
+      superTypes:
+        'Neos.Neos:Document': true
+        'KaufmannDigital.CookieConsent:PolicyPageMixin': true
+        ...
+  ```
+  
+  After that, simply select the policy page in your Neos backend.
+
+* Or use this snippet in your `Settings.yaml`:
+
+  ```yaml
+    KaufmannDigital:
+      CookieConsent:
+        #Global configuration of PolicyPage
+        policyPageNode: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of global page you want to link
+
+        #Configuration per site for multisite installations
+        #Replace site1/site2 with your sitename (/sites/sitename/node-a2ufd/.../)
+        policyPageNodes:
+          site1: 'c7a91aa8-fbac-4c24-8326-102eb7307180' #UUID of policy-page for /sites/site1
+          site2: '454d85b6-289b-11e9-b210-d663bd873d93' #UUID of policy-page for /sites/site2
+  ```
 
 _Congratulations, you added Cookie Consent to your Neos CMS page. That was easy, right?_
 
@@ -34,6 +50,7 @@ Changing the text
 -----------------
 
 The content inside Cookie Consent is managed via translations. If you want to change it, copy the `Packages/Application/KaufmannDigital.CookieConsent/Resources/Private/Translations` folder into your Site-Package and add this configuration to `Settings.yaml`:
+
 ```yaml
 KaufmannDigital:
   CookieConsent:
@@ -41,6 +58,7 @@ KaufmannDigital:
       package: 'Vendor.Package'
       source: 'Main'
 ```
+
 From now, the translation from your package (in this example "Vendor.Package") will be used.
 
 Translations for German and English are provided by this package. We are happy to get translations for your language via Pull-Request.
@@ -49,10 +67,11 @@ Changing layout & colors
 ------------------------
 
 You can also change colors and position. To do so, you have to add this snippet to `Settings.yaml`:
+
 ```yaml
 KaufmannDigital:
   CookieConsent:
-    position: 'bottom' # bottom, bottom-left, bottom-right, top, top-left or top-right 
+    position: 'bottom' # bottom, bottom-left, bottom-right, top, top-left or top-right
     theme: 'block' # block, classic, or edgeless
     palette:
       popup:
@@ -62,28 +81,32 @@ KaufmannDigital:
         background: 'rgb(255, 0, 0)' #like in css
         text: '#fff' #like in css
 ```
-You don't have to override all values. Just pick what you want to change. More configuration-options can be found at [cookieconsent.insites.com](https://cookieconsent.insites.com) 
+
+You don't have to override all values. Just pick what you want to change. More configuration-options can be found at [cookieconsent.insites.com](https://cookieconsent.insites.com)
 
 
 Using Opt-In or Opt-Out
 -----------------------
 
 In order to use Opt-In or Opt-Out functionality, you have to activate it in Settings:
+
 ```yaml
 KaufmannDigital:
   CookieConsent:
     type: 'opt-in' #Or 'opt-out' (depending on what you want to do)
-``` 
+```
+
 Afterwards, you can listen to the `kd-cookieconsent` event in JavaScript to en-/disable cookies:
+
 ```javascript
 document.addEventListener("kd-cookieconsent", function (e) {
     if (e.detail === 'enable-cookies') {
         //Enable your cookies here
-        //For Google Analytics: 
+        //For Google Analytics:
         window['ga-disable-UA-<YOUR-SITE-CODE>'] = false;
     } else if (e.detail === 'disable-cookies') {
         //Disable your cookies here
-        //For Google Analytics: 
+        //For Google Analytics:
         window['ga-disable-UA-<YOUR-SITE-CODE>'] = true;
     }
 });
@@ -93,12 +116,14 @@ Compile JS & CSS into your own files
 ------------------------------------
 
 If you don't want this Package to include it's own JS and CSS, you can disable it with in `Settings.yaml`:
+
 ```yaml
 KaufmannDigital:
   CookieConsent:
     includeJavaScript: false
     includeCss: false
 ```
+
 If you do so, you have to include JS & CSS of Cookie Consent in your files. [Instructions can be found here](https://github.com/insites/cookieconsent/#installation)
 
 
@@ -110,17 +135,17 @@ FAQs
 
 Known Bugs
 ----------
-Known Bugs are submitted as issue. Please have a look at it, before you supply a bug you found.  
-You did a bugfix? Great! Please submit it as PR to share it with other users. 
+Known Bugs are submitted as issue. Please have a look at it, before you supply a bug you found.
+You did a bugfix? Great! Please submit it as PR to share it with other users.
 
 Planned Features
 ----------------
-Planned functions are also created as issues and marked as such.  
+Planned functions are also created as issues and marked as such.
 You have another idea? Or would you like to help with the implementation? Gladly! Simply create new issues or PRs.
 
 Maintainer
 ----------
-This package is maintained by [Kaufmann Digital](https://www.kaufmann.digital).  
+This package is maintained by [Kaufmann Digital](https://www.kaufmann.digital).
 Feel free to send us your questions or requests to [support@kaufmann.digital](mailto:support@kaufmann.digital)
 
 License

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -21,6 +21,11 @@ prototype(Neos.Neos:Page) {
 
                 href = Neos.Neos:NodeUri {
                     node = Neos.Fusion:Case {
+                        policyPageProperty {
+                            condition = ${q(site).property('policyPage')}
+                            renderer = ${q(site).property('policyPage')}
+                        }
+
                         policyPageNodes {
                             condition = ${String.isBlank(Configuration.setting('KaufmannDigital.CookieConsent.policyPageNodes.' + site.name)) == false}
                             renderer = ${q(site).find('#' + Configuration.setting('KaufmannDigital.CookieConsent.policyPageNodes.' + site.name)).get(0)}
@@ -41,6 +46,6 @@ prototype(Neos.Neos:Page) {
         }
 
         @if.enabled = ${Configuration.setting('KaufmannDigital.CookieConsent.enable') == true}
-        @if.inBackend = ${site.context.inBackend == false}
+        @if.notInBackend = ${site.context.inBackend == false}
     }
 }

--- a/Resources/Private/Translations/de/NodeTypes/PolicyPageMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/PolicyPageMixin.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="KaufmannDigital.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="properties.policyPage" xml:space="preserve">
+        <source>Policy page</source>
+        <target xml:lang="de">Seite Datenschutzerklärung</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/PolicyPageMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/PolicyPageMixin.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="KaufmannDigital.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="properties.policyPage" xml:space="preserve">
+        <source>Policy page</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
This pull request adds a mixin that could be added to a document nodetype to be able to select the policy page from the neos backend. The readme was also adjusted for this. I also made some little change in the `Settings.yaml` (comment the section for mutlisite setup, as it needs to be updated by the user) and updated `@if.inBackend` to `@if.notInBackend` for better understanding.