### PR TITLE
Add properties: elements, compliance and cookie

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -33,3 +33,22 @@ KaufmannDigital:
       button:
         background: '#f1d600'
         text: '#000'
+    elements:
+      header: '<span class="cc-header">{{header}}</span>&nbsp;'
+      message: '<span id="cookieconsent:desc" class="cc-message">{{message}}</span>'
+      messagelink: '<span id="cookieconsent:desc" class="cc-message">{{message}} <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="{{href}}" target="_blank">{{link}}</a></span>'
+      dismiss: '<a aria-label="dismiss cookie message" tabindex="0" class="cc-btn cc-dismiss">{{dismiss}}</a>'
+      allow: '<a aria-label="allow cookies" tabindex="0" class="cc-btn cc-allow">{{allow}}</a>'
+      deny: '<a aria-label="deny cookies" tabindex="0" class="cc-btn cc-deny">{{deny}}</a>'
+      link: '<a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="{{href}}" target="_blank">{{link}}</a>'
+      close: '<span aria-label="dismiss cookie message" tabindex="0" class="cc-close">{{close}}</span>'
+    compliance:
+      'info': '<div class="cc-compliance">{{dismiss}}</div>'
+      'opt-in': '<div class="cc-compliance cc-highlight">{{dismiss}}{{allow}}</div>'
+      'opt-out': '<div class="cc-compliance cc-highlight">{{deny}}{{dismiss}}</div>'
+    cookie:
+      name: 'cookieconsent_status'
+      path: '/'
+      domain: ''
+      expiryDays: 365
+      secure: false

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -12,6 +12,9 @@ prototype(Neos.Neos:Page) {
             static = ${Configuration.setting('KaufmannDigital.CookieConsent.static')}
             theme = ${Configuration.setting('KaufmannDigital.CookieConsent.theme')}
             palette = ${Configuration.setting('KaufmannDigital.CookieConsent.palette')}
+            elements = ${Configuration.setting('KaufmannDigital.CookieConsent.elements')}
+            compliance = ${Configuration.setting('KaufmannDigital.CookieConsent.compliance')}
+            cookie = ${Configuration.setting('KaufmannDigital.CookieConsent.cookie')}
             content = Neos.Fusion:RawArray {
                 message = ${Translation.translate('message', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}
                 dismiss = ${Translation.translate('dismiss', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}


### PR DESCRIPTION
With this little PR the package gets the possibility to store your own html markups, adjust the compliance buttons and manage the cookie that will be set