### PR TITLE
Add `content.header` and `layout` options

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -26,6 +26,7 @@ KaufmannDigital:
     position: 'bottom'
     static: false
     theme: 'block'
+    layout: 'basic'
     palette:
       popup:
         background: '#000'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To configure the policy-link, you have the following two options:
         'KaufmannDigital.CookieConsent:PolicyPageMixin': true
         ...
   ```
-  
+
   After that, simply select the policy page in your Neos backend.
 
 * Or use this snippet in your `Settings.yaml`:
@@ -73,6 +73,7 @@ KaufmannDigital:
   CookieConsent:
     position: 'bottom' # bottom, bottom-left, bottom-right, top, top-left or top-right
     theme: 'block' # block, classic, or edgeless
+    layout: 'basic' # basic, basic-close or basic-header
     palette:
       popup:
         background: '#000' #like in css

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -17,6 +17,7 @@ prototype(Neos.Neos:Page) {
             compliance = ${Configuration.setting('KaufmannDigital.CookieConsent.compliance')}
             cookie = ${Configuration.setting('KaufmannDigital.CookieConsent.cookie')}
             content = Neos.Fusion:RawArray {
+                header = ${Translation.translate('header', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}
                 message = ${Translation.translate('message', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}
                 dismiss = ${Translation.translate('dismiss', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}
                 allow = ${Translation.translate('allow', null, [], Configuration.setting('KaufmannDigital.CookieConsent.translations.source'), Configuration.setting('KaufmannDigital.CookieConsent.translations.package'))}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -11,6 +11,7 @@ prototype(Neos.Neos:Page) {
             position = ${Configuration.setting('KaufmannDigital.CookieConsent.position')}
             static = ${Configuration.setting('KaufmannDigital.CookieConsent.static')}
             theme = ${Configuration.setting('KaufmannDigital.CookieConsent.theme')}
+            layout = ${Configuration.setting('KaufmannDigital.CookieConsent.layout')}
             palette = ${Configuration.setting('KaufmannDigital.CookieConsent.palette')}
             elements = ${Configuration.setting('KaufmannDigital.CookieConsent.elements')}
             compliance = ${Configuration.setting('KaufmannDigital.CookieConsent.compliance')}

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" source-language="de" datatype="plaintext">
         <body>
+            <trans-unit id="header">
+                <source>Cookie Richtlinien</source>
+            </trans-unit>
             <trans-unit id="message">
                 <source>Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer</source>
             </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" source-language="en" datatype="plaintext">
         <body>
+            <trans-unit id="header">
+                <source>Cookie Policy</source>
+            </trans-unit>
             <trans-unit id="message">
                 <source>This website uses cookies to ensure you get the best experience on our website.</source>
             </trans-unit>


### PR DESCRIPTION
![Screenshot_2019-05-23_14-05-37](https://user-images.githubusercontent.com/2522299/58251533-29066f80-7d64-11e9-9b7c-bd7995422b9f.png)

This adds the possibility of defining a header text for the cookie consent popup. Also, the `layout` option is made configurable, since the default of `basic` does not render the header.

