### PR TITLE
Autoload translations for Neos 5

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,6 +3,11 @@ Neos:
     fusion:
       autoInclude:
         KaufmannDigital.CookieConsent: true
+    userInterface:
+      translation:
+        autoInclude:
+          'KaufmannDigital.CookieConsent':
+            - 'NodeTypes/*'
 
 KaufmannDigital:
   CookieConsent:


### PR DESCRIPTION
Labels in the backend aren't automatically loaded in Neos 5. This fixes it.

See https://docs.neos.io/cms/manual/rendering/translating-text-in-fusion#load-translation-files and https://docs.neos.io/cms/manual/content-repository/nodetype-translations#define-translations